### PR TITLE
Feature/add class metrics

### DIFF
--- a/moonwatcher/check.py
+++ b/moonwatcher/check.py
@@ -22,6 +22,7 @@ class Check(MoonwatcherObject):
         dataset_or_slice: Union[MoonwatcherDataset, Slice],
         metric: str,
         metric_parameters: Optional[Dict] = None,
+        metric_class: str = None,
         description: Optional[str] = None,
         metadata: Dict[str, Any] = None,
         operator: Optional[str] = None,
@@ -51,6 +52,7 @@ class Check(MoonwatcherObject):
         self.dataset_or_slice = dataset_or_slice
         self.metric = metric
         self.metric_parameters = metric_parameters
+        self.metric_class = metric_class
         self.store()
 
     def _upload(self):
@@ -90,6 +92,7 @@ class Check(MoonwatcherObject):
             dataset_or_slice=self.dataset_or_slice,
             metric=self.metric,
             metric_parameters=self.metric_parameters,
+            metric_class=self.metric_class,
         )
         report = {
             "check_name": self.name,
@@ -357,6 +360,7 @@ def automated_checking(
                 name=check_name,
                 dataset_or_slice=mw_slice,
                 metric=check["metric"],
+                metric_class=check.get("metric_class", None),
                 operator=check.get("operator", None),
                 value=check.get("value", None),
             )
@@ -375,6 +379,7 @@ def automated_checking(
             name=check_name,
             dataset_or_slice=mw_dataset,
             metric=check["metric"],
+            metric_class=check.get("metric_class", None),
             operator=check.get("operator", None),
             value=check.get("value", None),
         )

--- a/moonwatcher/check.py
+++ b/moonwatcher/check.py
@@ -2,10 +2,9 @@ import json
 from pathlib import Path
 from typing import Optional, List, Union, Dict, Any
 
-import numpy as np
-
 from moonwatcher.utils.data import OPERATOR_DICT
 from moonwatcher.dataset.dataset import MoonwatcherDataset, Slice
+from moonwatcher.dataset.metadata import ATTRIBUTE_FUNCTIONS
 from moonwatcher.model.model import MoonwatcherModel
 from moonwatcher.metric import calculate_metric
 from moonwatcher.utils.helpers import get_current_timestamp
@@ -323,7 +322,10 @@ def automated_checking(
 
     # Add Metadata
     for metadata_key in metadata_keys:
-        mw_dataset.add_predefined_metadata(metadata_key)
+        if metadata_key in ATTRIBUTE_FUNCTIONS:
+            mw_dataset.add_predefined_metadata(metadata_key)
+        else:
+            mw_dataset.add_metadata_from_groundtruths(metadata_key)
     if metadata_list:
         mw_dataset.add_metadata_from_list(metadata_list)
 

--- a/moonwatcher/check.py
+++ b/moonwatcher/check.py
@@ -385,7 +385,9 @@ def automated_checking(
         )
         check_objects.append(new_check)
 
-    entire_dataset_check_suite = CheckSuite(name=f"Test_{mw_dataset.name}", checks=check_objects)
+    entire_dataset_check_suite = CheckSuite(
+        name=f"Test_{mw_dataset.name}", checks=check_objects
+    )
     entire_dataset_test_results = entire_dataset_check_suite(model=mw_model, show=True)
     all_test_results[mw_dataset.name] = entire_dataset_test_results
 

--- a/moonwatcher/dataset/metadata.py
+++ b/moonwatcher/dataset/metadata.py
@@ -22,7 +22,7 @@ def compute_resolution(image):
     return height * width
 
 
-_ATTRIBUTE_FUNCTIONS = {
+ATTRIBUTE_FUNCTIONS = {
     "brightness": compute_brightness,
     "contrast": compute_contrast,
     "saturation": compute_saturation,

--- a/moonwatcher/metric.py
+++ b/moonwatcher/metric.py
@@ -86,9 +86,7 @@ def calculate_metric_internal(
             )
 
         if not groundtruths.size or not predictions.size:
-            raise ValueError(
-                "Ground truths and/or predictions are empty! Ensure your dataset or slice contains data and has been properly processed."
-            )
+            return -1.0
 
         try:
             num_classes = len(dataset.label_to_name)
@@ -143,9 +141,7 @@ def calculate_metric_internal(
             )
 
             if not groundtruths or not predictions:
-                raise ValueError(
-                    "Ground truths and/or predictions are empty! Ensure your dataset or slice contains data and has been properly processed."
-                )
+                return -1.0
 
             for gt in groundtruths:
                 if "boxes" not in gt or len(gt["boxes"]) == 0:

--- a/moonwatcher/metric.py
+++ b/moonwatcher/metric.py
@@ -154,7 +154,17 @@ def calculate_metric_internal(
             metric_value = metric_function.compute()
 
             if metric_class:
-                metric_value = metric_value.get(metric_class, 0.0)
+                if metric in ["mAP", "mAP_small", "mAP_medium", "mAP_large"]:
+                    index = torch.where(metric_value["classes"] == metric_class)[0]
+                    metric_value = (
+                        metric_value["map_per_class"][index].item()
+                        if index.numel() > 0
+                        else 0.0
+                    )
+                    metric_value = 0.0 if metric_value < 0.0 else metric_value
+                else:
+                    metric_class = "iou/cl_" + str(metric_class)
+                    metric_value = metric_value.get(metric_class, 0.0)
             else:
                 metric_value = metric_value[_METRIC_KEYS[metric]]
 

--- a/tests/test_metadata.py
+++ b/tests/test_metadata.py
@@ -6,7 +6,7 @@ from moonwatcher.dataset.metadata import (
     compute_contrast,
     compute_saturation,
     compute_resolution,
-    _ATTRIBUTE_FUNCTIONS,
+    ATTRIBUTE_FUNCTIONS,
 )
 
 
@@ -44,7 +44,7 @@ def test_compute_resolution():
 
 def test_attribute_functions():
     image = np.ones((100, 100, 3), dtype=np.uint8) * 128
-    assert _ATTRIBUTE_FUNCTIONS["brightness"](image) == compute_brightness(image)
-    assert _ATTRIBUTE_FUNCTIONS["contrast"](image) == compute_contrast(image)
-    assert _ATTRIBUTE_FUNCTIONS["saturation"](image) == compute_saturation(image)
-    assert _ATTRIBUTE_FUNCTIONS["resolution"](image) == compute_resolution(image)
+    assert ATTRIBUTE_FUNCTIONS["brightness"](image) == compute_brightness(image)
+    assert ATTRIBUTE_FUNCTIONS["contrast"](image) == compute_contrast(image)
+    assert ATTRIBUTE_FUNCTIONS["saturation"](image) == compute_saturation(image)
+    assert ATTRIBUTE_FUNCTIONS["resolution"](image) == compute_resolution(image)


### PR DESCRIPTION
### Added per-class metric calculation and groundtruth-based slicing

#### Features Added:
1. **Per-Class Metrics**:
   - Introduced the optional `metric_class` parameter for checks.
   - This parameter can be set to either the numerical class (e.g., 0,1,2,...) or the class label (e.g., "airplane").
   - When set, the metric will return values for the specified class rather than averaging over all classes.
   - For example, if `metric_class` is set to "airplane", the IOU metric will be calculated exclusively for the airplane class instead of all objects.

2. **Groundtruth-Based Slicing**:
   - Enabled the addition of class occurrence counts in images as metadata.
   - This allows creating slices based on the number of occurrences of a class in a given image.
   - For instance, in object detection, you can create a slice where each image contains at least 3 cats.
   - Similarly, in multi-class classification, you can slice images based on the presence or absence of a specific class tag (e.g., "airplane").
   - To utilize groundtruth-based slicing, handle it similarly to the predefined metadata functions. Instead of using "brightness" or "saturation," select the class as the metadata key (e.g., "airplane").